### PR TITLE
Switch Flye to use conda

### DIFF
--- a/envs/MIntO_base.yml
+++ b/envs/MIntO_base.yml
@@ -8,8 +8,12 @@ dependencies:
   - bedtools=2.31.0
   - bwa-mem2=2.2.1
   - coverm=0.6.1
+  - fastp=0.23
+  - fastqc=0.12
+  - flye=2.9
   - megahit=1.2.9
   - msamtools=1.1.3
+  - multiqc=1.17
   - samtools=1.14
   - seqtk=1.4
   - seqkit=2.5.1

--- a/smk/assembly.smk
+++ b/smk/assembly.smk
@@ -404,8 +404,8 @@ rule nanopore_assembly_metaflye:
     threads: 16
     params:
         options = lambda wildcards: config['METAFLYE_presets'][wildcards.assembly_preset]
-    singularity: "docker://quay.io/biocontainers/flye:2.9--py38h69e0bdc_0"
-    #"docker://quay.io/biocontainers/flye:2.8.3--py38h69e0bdc_1"
+    conda:
+        config["minto_dir"]+"/envs/MIntO_base.yml"
     shell:
         """
         mkdir -p $(dirname {output[0]})


### PR DESCRIPTION
Switching Flye to use conda environment (MIntO_base.yml) instead of singularity container