### PR TITLE
Software and database versions

### DIFF
--- a/configuration/QC_2.yaml
+++ b/configuration/QC_2.yaml
@@ -49,6 +49,8 @@ BWA_host_memory: 40
 TAXA_threads: 8
 TAXA_memory: 10
 TAXA_profiler: motus_rel,metaphlan
+metaphlan_version: 4.0.6
+motus_version: 3.0.3
 
 #########################
 # K-mer based comparison

--- a/scripts/collate_gene_annotations.py
+++ b/scripts/collate_gene_annotations.py
@@ -25,7 +25,7 @@ for filename in input_annotations:
 
     # eggNOG annotations
     if filename.endswith('eggNOG.tsv'):
-        eggnog = pd.read_csv(filename, sep="\t", index_col=False)
+        eggnog = pd.read_csv(filename, sep="\t", index_col=False, comment='#')
         # Prefix all columns with 'eggNOG.'
         eggnog = eggnog.rename(lambda x: f'eggNOG.{x}', axis='columns')
         # Fix some names and remove prefix from ID
@@ -37,7 +37,7 @@ for filename in input_annotations:
 
     # dbCAN annotations
     elif filename.endswith('dbCAN.tsv'):
-        dbcan = pd.read_csv(filename, sep="\t", index_col=False)
+        dbcan = pd.read_csv(filename, sep="\t", index_col=False, comment='#')
         # Prefix eCAMI columns with 'dbCAN.'
         dbcan = dbcan.rename(columns={"eCAMI.submodule" : "dbCAN.eCAMI_submodule",
                                       "eCAMI.subfamily" : "dbCAN.eCAMI_subfamily"})
@@ -46,7 +46,7 @@ for filename in input_annotations:
 
     # kofam annotations
     elif filename.endswith('kofam.tsv'):
-        kofam = pd.read_csv(filename, sep="\t", index_col=False)
+        kofam = pd.read_csv(filename, sep="\t", index_col=False, comment='#')
         # Prefix all columns with 'kofam.'
         kofam = kofam.rename(columns={"kofam_KO"      : "kofam.KEGG_KO",
                                       "kofam_Module"  : "kofam.KEGG_Module",

--- a/smk/QC_0.smk
+++ b/smk/QC_0.smk
@@ -21,6 +21,15 @@ localrules: qc0_fake_move_for_multiqc, qc0_create_multiqc, \
 include: 'include/cmdline_validator.smk'
 include: 'include/config_parser.smk'
 
+module print_versions:
+    snakefile:
+        'include/versions.smk'
+    config: config
+
+use rule QC_0_base, QC_0_rpkg from print_versions as version_*
+
+snakefile_name = print_versions.get_smk_filename()
+
 if config['raw_reads_dir'] is None:
     print('ERROR in ', config_path, ': raw_reads_dir variable in configuration yaml file is empty. Please, complete ', config_path)
 else:
@@ -120,7 +129,9 @@ rule all:
         qc1_read_length_output(),
         qc1_read_length_cutoff_output(),
         qc1_config_yml_output(),
-        qc0_multiqc_summary_output()
+        qc0_multiqc_summary_output(),
+        print_versions.get_version_output(snakefile_name)
+    default_target: True
 
 
 ###############################################################################################

--- a/smk/QC_1.smk
+++ b/smk/QC_1.smk
@@ -19,7 +19,6 @@ localrules: qc1_check_read_length_merge, qc1_cumulative_read_len_plot, qc2_confi
 #   config_path, project_id, omics, working_dir, minto_dir, script_dir, metadata
 include: 'include/cmdline_validator.smk'
 include: 'include/config_parser.smk'
-include: 'include/versions.smk'
 
 module print_versions:
     snakefile:

--- a/smk/QC_1.smk
+++ b/smk/QC_1.smk
@@ -19,6 +19,16 @@ localrules: qc1_check_read_length_merge, qc1_cumulative_read_len_plot, qc2_confi
 #   config_path, project_id, omics, working_dir, minto_dir, script_dir, metadata
 include: 'include/cmdline_validator.smk'
 include: 'include/config_parser.smk'
+include: 'include/versions.smk'
+
+module print_versions:
+    snakefile:
+        'include/versions.smk'
+    config: config
+
+use rule QC_1_base, QC_1_rpkg from print_versions as version_*
+
+snakefile_name = print_versions.get_smk_filename()
 
 if config['raw_reads_dir'] is None:
     print('ERROR in ', config_path, ': raw_reads_dir variable in configuration yaml file is empty. Please, complete ', config_path)
@@ -106,7 +116,9 @@ rule all:
         #qc1_trim_quality_output(),
         #qc1_check_read_length_output(),
         qc1_read_length_cutoff_output(),
-        qc1_config_yml_output()
+        qc1_config_yml_output(),
+        print_versions.get_version_output(snakefile_name)
+    default_target: True
 
 
 ###############################################################################################

--- a/smk/QC_1.smk
+++ b/smk/QC_1.smk
@@ -529,6 +529,8 @@ ___EOF___
 TAXA_threads: 8
 TAXA_memory: 10
 TAXA_profiler: motus_rel,metaphlan
+metaphlan_version: 4.0.6
+motus_version: 3.0.3
 
 #########################
 # K-mer based comparison

--- a/smk/QC_2.smk
+++ b/smk/QC_2.smk
@@ -22,6 +22,15 @@ include: 'include/cmdline_validator.smk'
 include: 'include/config_parser.smk'
 include: 'include/locations.smk'
 
+module print_versions:
+    snakefile:
+        'include/versions.smk'
+    config: config
+
+use rule QC_2_base, QC_2_rpkg, QC_2_mpl, QC_2_motus from print_versions as version_*
+
+snakefile_name = print_versions.get_smk_filename()
+
 localrules: qc2_filter_config_yml_assembly, qc2_filter_config_yml_mapping, \
             metaphlan_combine_profiles, motus_combine_profiles, motus_calc_motu, \
             plot_taxonomic_profile, plot_sourmash_kmers 
@@ -154,7 +163,11 @@ else:
 
 # TODO: Read this from yaml file and remove hard-coding
 metaphlan_version = "4.0.6"
+if metaphlan_version in config and config['metaphlan_version'] is not None:
+    metaphlan_version = config['metaphlan_version']
 motus_version = "3.0.3"
+if motus_version in config and config['motus_version'] is not None:
+    motus_version = config['motus_version']
 
 taxonomies = taxonomy.split(",")
 for t in taxonomies:
@@ -295,7 +308,9 @@ rule all:
         merged_sample_output(),
         taxonomy_plot_output(),
         smash_plot_output(),
-        next_step_config_yml_output()
+        next_step_config_yml_output(),
+        print_versions.get_version_output(snakefile_name)
+    default_target: True
 
 # Get a sorted list of runs for a sample
 

--- a/smk/assembly.smk
+++ b/smk/assembly.smk
@@ -22,6 +22,15 @@ include: 'include/config_parser.smk'
 include: 'include/locations.smk'
 include: 'include/fasta_bam_helpers.smk'
 
+module print_versions:
+    snakefile:
+        'include/versions.smk'
+    config: config
+
+use rule assembly_base from print_versions as version_*
+
+snakefile_name = print_versions.get_smk_filename()
+
 # Variables from configuration yaml file
 
 # Make list of illumina samples, if ILLUMINA in config
@@ -198,7 +207,9 @@ rule all:
         illumina_single_assembly_output(),
         illumina_co_assembly_output(),
         nanopore_single_assembly_output(),
-        hybrid_assembly_output()
+        hybrid_assembly_output(),
+        print_versions.get_version_output(snakefile_name)
+    default_target: True
 
 ###############################################################################################
 # Correct Illumina reads using SPAdes' spadeshammer

--- a/smk/binning_preparation.smk
+++ b/smk/binning_preparation.smk
@@ -11,6 +11,15 @@ import snakemake
 include: 'include/cmdline_validator.smk'
 include: 'include/fasta_bam_helpers.smk'
 
+module print_versions:
+    snakefile:
+        'include/versions.smk'
+    config: config
+
+use rule binning_preparation_base, binning_preparation_avamb from print_versions as version_*
+
+snakefile_name = print_versions.get_smk_filename()
+
 localrules: filter_contigs_illumina_single, filter_contigs_illumina_coas, \
             filter_contigs_nanopore, filter_contigs_illumina_single_nanopore, \
             check_depth_batches, combine_contigs_depth_batches, combine_fasta_batches, \
@@ -268,7 +277,9 @@ rule all:
                 min_seq_length = config['MIN_FASTA_LENGTH']),
         config_yaml = "{wd}/{omics}/mags_generation.yaml".format(
                 wd = working_dir,
-                omics = config['omics'])
+                omics = config['omics']),
+        versions = print_versions.get_version_output(snakefile_name)
+    default_target: True
 
 ###############################################################################################
 # Filter contigs from

--- a/smk/data_integration.smk
+++ b/smk/data_integration.smk
@@ -82,17 +82,21 @@ elif map_reference in ('genes_db'):
         print('ERROR in ', config_path, ': ANNOTATION_ids variable in configuration yaml file is empty. Please, complete ', config_path)
     else:
         funct_opt=config['ANNOTATION_ids']
-
+funct_opt_list = ','.join(['"' + id + '"' for id in funct_opt])
 
 if omics == 'metaG':
-    omics_opt='metaG'
     omics_prof='A'
 elif omics == 'metaT':
-    omics_opt='metaT'
     omics_prof='T'
 elif omics == 'metaG_metaT':
-    omics_opt=['metaG','metaT']
     omics_prof=['A','T','E']
+
+print('NOTE: MIntO is using ', omics, ' as omics variable.')
+
+for omics_type in omics.split("_"):
+    omics_folder = path.join(working_dir, omics_type)
+    if not path.exists(omics_folder):
+        print('ERROR in ', omics, ': setting, the folder', omics_folder, 'does not exist.')
 
 if map_reference == 'MAG':
     post_analysis_dir="9-MAG-genes-post-analysis"
@@ -109,9 +113,8 @@ elif map_reference == 'genes_db':
     post_analysis_out="db-genes"
     post_analysis_genome="None"
 
-print('NOTE: MIntO is using "' + annot_file + '" as ANNOTATION_file variable.')
+print('NOTE: MIntO is using ', annot_file ,' as ANNOTATION_file variable.')
 
-funct_opt_list = ','.join(['"' + id + '"' for id in funct_opt])
 print('NOTE: MIntO is using ', funct_opt, ' as ANNOTATION_ids variable.')
 
 
@@ -456,6 +459,7 @@ rule combine_feature_counts:
                                             funcat=funct_opt)
     output:
         combined="{somewhere}/{something}_features.tsv",
+    localrule: True
     run:
         import pandas as pd
 
@@ -475,6 +479,9 @@ rule make_feature_count_plot:
         tsv=rules.combine_feature_counts.output.combined
     output:
         pdf="{somewhere}/plots/{something}_features.pdf"
+    resources:
+        mem=config["MERGE_memory"]
+    threads: 1
     conda:
         config["minto_dir"]+"/envs/r_pkgs.yml" #R
     shell:

--- a/smk/data_integration.smk
+++ b/smk/data_integration.smk
@@ -18,6 +18,15 @@ import re
 include: 'include/cmdline_validator.smk'
 include: 'include/config_parser.smk'
 
+module print_versions:
+    snakefile:
+        'include/versions.smk'
+    config: config
+
+use rule integration_rpkg from print_versions as version_*
+
+snakefile_name = print_versions.get_smk_filename()
+
 # some variables
 
 main_factor = None
@@ -178,7 +187,9 @@ rule all:
     input:
         integration_merge_profiles(),
         integration_gene_profiles(),
-        integration_function_profiles()
+        integration_function_profiles(),
+        print_versions.get_version_output(snakefile_name)
+    default_target: True
 
 ###############################################################################################
 # Prepare gene profile

--- a/smk/dependencies.smk
+++ b/smk/dependencies.smk
@@ -501,6 +501,12 @@ rule motus_db:
             if [ $? -eq 0 ]; then
                 echo 'mOTUs3 database download: OK'
                 echo OK > {output}
+
+                # place db into data folder
+                $MOTUS_DB_PATH=$(find "$(dirname $(which motus))/../lib" -type d -iname db_mOTU | head -1 )
+                rsync -a $MOTUS_DB_PATH {minto_dir}/data/motus/{motus_version}/
+
+                rm -rf $MOTUS_DB_PATH
             else
                 echo 'mOTUs3 database download: FAIL'
             fi

--- a/smk/gene_abundance.smk
+++ b/smk/gene_abundance.smk
@@ -21,6 +21,15 @@ include: 'include/cmdline_validator.smk'
 include: 'include/config_parser.smk'
 include: 'include/locations.smk'
 
+module print_versions:
+    snakefile:
+        'include/versions.smk'
+    config: config
+
+use rule abundance_base, abundance_rpkg from print_versions as version_*
+
+snakefile_name = print_versions.get_smk_filename()
+
 # We prefer original non-error-corrected reads for profiling to preserve strain variation in population
 read_dir=get_qc2_output_location(omics)
 
@@ -208,7 +217,9 @@ rule all:
         combined_genome_profiles(),
         combined_gene_abundance_profiles(),
         mapping_statistics(),
-        config_yaml()
+        config_yaml(),
+        print_versions.get_version_output(snakefile_name)
+    default_target: True
 
 ###############################################################################################
 # Useful python functions

--- a/smk/gene_annotation.smk
+++ b/smk/gene_annotation.smk
@@ -19,6 +19,15 @@ localrules: rename_prokka_sequences, combine_annotation_outputs, combine_individ
 include: 'include/cmdline_validator.smk'
 include: 'include/config_parser.smk'
 
+module print_versions:
+    snakefile:
+        'include/versions.smk'
+    config: config
+
+use rule annotation_base from print_versions as version_*
+
+snakefile_name = print_versions.get_smk_filename()
+
 if config['map_reference'] in ("MAG", "reference_genome"):
     map_reference=config["map_reference"]
 else:
@@ -88,7 +97,9 @@ rule all:
         predicted_genes_collate_out(),
         "{wd}/DB/{post_analysis_dir}/{post_analysis_out}.bed".format(wd = working_dir,
                     post_analysis_dir = post_analysis_dir,
-                    post_analysis_out = post_analysis_out)
+                    post_analysis_out = post_analysis_out),
+        print_versions.get_version_output(snakefile_name)
+    default_target: True
 
 
 ###############################################################################################

--- a/smk/include/versions.smk
+++ b/smk/include/versions.smk
@@ -1,0 +1,493 @@
+#!/usr/bin/env python
+
+'''
+Print software and database versions for each module
+
+Authors: Judit Szarvas
+'''
+
+import sys
+from os import path
+
+include: 'config_parser.smk'
+
+def get_smk_filename():
+    if '-s' in sys.argv:
+        i = sys.argv.index('-s')
+    elif '--snakefile' in sys.argv:
+        i = sys.argv.index('--snakefile')
+    smk_name = path.splitext(path.basename(sys.argv[i+1]))[0]
+    return smk_name
+
+def get_version_output(smkfilename):
+    smkfiles = ["QC_0", "QC_1", "QC_2", "assembly", "binning_preparation", "mags_generation", "gene_annotation", "gene_abundance", "data_integration", "module_tester"]
+    if smkfilename in smkfiles:
+        result = "{wd}/output/versions/{smk}.flag".format(wd=working_dir, smk=smkfilename)
+        return(result)
+    else:
+        print('WARNING:', smkfilename, 'not set up for printing software versions')
+    return()
+
+snakefile_name = get_smk_filename()
+
+metaphlan_version = ""
+if "metaphlan_version" in config and config['metaphlan_version'] is not None:
+    metaphlan_version = config['metaphlan_version']
+motus_version = ""
+if "motus_version" in config and config['motus_version'] is not None:
+    motus_version = config['motus_version']
+
+spades_script = 'spades.py' # from conda environment
+if 'METASPADES_custom_build' in config:
+    spades_script = config['METASPADES_custom_build']
+
+ppl_version = ""
+gtdb_version = ""
+if "PHYLOPHLAN_TAXONOMY_VERSION" in config and config["PHYLOPHLAN_TAXONOMY_VERSION"] is not None:
+    ppl_version = config["PHYLOPHLAN_TAXONOMY_VERSION"]
+if "GTDB_TAXONOMY_VERSION" in config and config["GTDB_TAXONOMY_VERSION"] is not None:
+    gtdb_version = config["GTDB_TAXONOMY_VERSION"]
+
+##################################
+#  Rules for TESTING
+##################################
+
+rule test_base:
+    output:
+        temp("{wd}/output/versions/module_tester.flag")
+    resources:
+        mem=1
+    threads:
+        1
+    localrule: True
+    conda:
+        config["minto_dir"]+"/envs/MIntO_base.yml"
+    shell:
+        """
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        touch {output}
+        """
+
+##################################
+#  Rules for QC_0
+##################################
+
+rule QC_0_base:
+    output:
+        temp("{wd}/output/versions/QC_0_base.flag")
+    resources:
+        mem=1
+    threads:
+        1
+    localrule: True
+    conda:
+        config["minto_dir"]+"/envs/MIntO_base.yml"
+    shell:
+        """
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        fastqc --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo $(fastp --version 2>&1) >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        touch {output}
+        """
+
+rule QC_0_rpkg:
+    input:
+        "{wd}/output/versions/QC_0_base.flag".format(wd=working_dir)
+    output:
+        temp("{wd}/output/versions/QC_0.flag")
+    resources:
+        mem=1
+    threads: 1
+    localrule: True
+    conda:
+        config["minto_dir"]+"/envs/r_pkgs.yml"
+    shell:
+        """
+        Rscript --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        touch {output}
+        """
+
+##################################
+#  Rules for QC_1
+##################################
+
+rule QC_1_base:
+    output:
+        temp("{wd}/output/versions/QC_1_base.flag")
+    resources:
+        mem=1
+    threads:
+        1
+    localrule: True
+    conda:
+        config["minto_dir"]+"/envs/MIntO_base.yml"
+    shell:
+        """
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "trimmomatic v$(trimmomatic -version)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        touch {output}
+        """
+
+rule QC_1_rpkg:
+    input:
+        "{wd}/output/versions/QC_1_base.flag".format(wd=working_dir)
+    output:
+        temp("{wd}/output/versions/QC_1.flag")
+    resources:
+        mem=1
+    threads: 1
+    localrule: True
+    conda:
+        config["minto_dir"]+"/envs/r_pkgs.yml"
+    shell:
+        """
+        Rscript --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        touch {output}
+        """
+
+##################################
+#  Rules for QC_2
+##################################
+
+rule QC_2_base:
+    output:
+        temp("{wd}/output/versions/QC_2_base.flag")
+    resources:
+        mem=1
+    threads:
+        1
+    localrule: True
+    conda:
+        config["minto_dir"]+"/envs/MIntO_base.yml"
+    shell:
+        """
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        seqkit version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "bwa-mem2 v$(bwa-mem2 version 2> /dev/null)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "msamtools $(msamtools 2>&1 | grep "Version" | cut -d" " -f 2)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "samtools $(samtools 2>&1 | grep "Version" | cut -d" " -f 2)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "$(sortmerna 2>&1 | grep "Program" | cut -d" " -f 9-11)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        sourmash --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        touch {output}
+        """
+
+rule QC_2_mpl:
+    input:
+        "{wd}/output/versions/QC_2_base.flag".format(wd=working_dir)
+    output:
+        temp("{wd}/output/versions/QC_2_mpl.flag")
+    resources:
+        mem=1 
+    threads: 1
+    localrule: True
+    conda:
+        config["minto_dir"]+"/envs/metaphlan.yml"
+    shell:
+        """
+        metaphlan --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "metaphlan database $(basename $(ls {minto_dir}/data/metaphlan/{metaphlan_version}/*.csv) | sed 's|_VINFO.csv||')" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        touch {output}
+        """
+
+rule QC_2_motus:
+    input:
+        "{wd}/output/versions/QC_2_mpl.flag".format(wd=working_dir)
+    output:
+        temp("{wd}/output/versions/QC_2_motus.flag")
+    resources:
+        mem=1
+    threads: 1
+    localrule: True
+    conda:
+        config["minto_dir"]+"/envs/motus_env.yml"
+    shell:
+        """
+        motus --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        touch {output}
+        """
+
+rule QC_2_rpkg:
+    input:
+        "{wd}/output/versions/QC_2_motus.flag".format(wd=working_dir)
+    output:
+        temp("{wd}/output/versions/QC_2.flag")
+    params:
+        fn=snakefile_name
+    resources:
+        mem=1
+    threads: 1
+    localrule: True
+    conda:
+        config["minto_dir"]+"/envs/r_pkgs.yml"
+    shell:
+        """
+        Rscript --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        touch {output}
+        """
+
+##################################
+#  Rules for Assembly
+##################################
+
+rule assembly_base:
+    output:
+        temp("{wd}/output/versions/assembly.flag")
+    resources:
+        mem=1
+    threads:
+        1
+    localrule: True
+    conda:
+        config["minto_dir"]+"/envs/MIntO_base.yml"
+    shell:
+        """
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        $(which {spades_script}) --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        megahit --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "flye v$(flye --version)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        touch {output}
+        """
+
+##################################
+#  Rules for binning_preparation
+##################################
+
+rule binning_preparation_base:
+    output:
+        temp("{wd}/output/versions/binprep_base.flag")
+    resources:
+        mem=1
+    threads:
+        1
+    localrule: True
+    conda:
+        config["minto_dir"]+"/envs/MIntO_base.yml"
+    shell:
+        """
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "bwa-mem2 v$(bwa-mem2 version 2> /dev/null)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "msamtools $(msamtools 2>&1 | grep "Version" | cut -d" " -f 2)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "samtools $(samtools 2>&1 | grep "Version" | cut -d" " -f 2)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        coverm --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        touch {output}
+        """
+
+rule binning_preparation_avamb:
+    input:
+        "{wd}/output/versions/binprep_base.flag".format(wd=working_dir)
+    output:
+        temp("{wd}/output/versions/binning_preparation.flag")
+    resources:
+        mem=1
+    threads: 1
+    localrule: True
+    conda:
+        config["minto_dir"]+"/envs/avamb.yml"
+    shell:
+        """
+        vamb --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        touch {output}
+        """
+
+##################################
+#  Rules for mags_generation
+##################################
+
+rule mags_base:
+    output:
+        temp("{wd}/output/versions/mags_base.flag")
+    resources:
+        mem=1
+    threads:
+        1
+    localrule: True
+    conda:
+        config["minto_dir"]+"/envs/MIntO_base.yml"
+    shell:
+        """
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        coverm --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        touch {output}
+        """
+
+rule mags_avamb:
+    input:
+        "{wd}/output/versions/mags_base.flag".format(wd=working_dir)
+    output:
+        temp("{wd}/output/versions/mags_avamb.flag")
+    resources:
+        mem=1
+    threads: 1
+    localrule: True
+    conda:
+        config["minto_dir"]+"/envs/avamb.yml"
+    shell:
+        """
+        vamb --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        touch {output}
+        """
+
+rule mags_checkm2:
+    input:
+        "{wd}/output/versions/mags_base.flag".format(wd=working_dir)
+    output:
+        temp("{wd}/output/versions/mags_checkm.flag")
+    resources:
+        mem=1
+    threads: 1
+    localrule: True
+    conda:
+        config["minto_dir"]+"/envs/checkm2.yml"
+    shell:
+        """
+        echo "checkm2 v$(checkm2 predict --version)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        touch {output}
+        """
+
+rule mags_ppl:
+    input:
+        "{wd}/output/versions/mags_checkm.flag".format(wd=working_dir)
+    output:
+        temp("{wd}/output/versions/mags_ppl.flag")
+    params:
+        db=ppl_version
+    resources:
+        mem=1
+    threads: 1
+    localrule: True
+    conda:
+        config["minto_dir"]+"/envs/mags.yml"
+    shell:
+        """
+        phylophlan --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "phylophlan database {params.db}" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        touch {output}
+        """
+
+rule mags_gtdb:
+    input:
+        "{wd}/output/versions/mags_ppl.flag".format(wd=working_dir)
+    output:
+        temp("{wd}/output/versions/mags_generation.flag")
+    params:
+        db=gtdb_version
+    resources:
+        mem=1
+    threads: 1
+    localrule: True
+    conda:
+        config["minto_dir"]+"/envs/gtdb.yml"
+    shell:
+        """
+        echo "gtdbtk v$(gtdbtk --version | cut -d" " -f 3 | head -n 1)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "gtdbtk database {params.db}" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        touch {output}
+        """
+
+##################################
+#  Rules for gene_annotation
+##################################
+
+rule annotation_base:
+    output:
+        temp("{wd}/output/versions/gene_annotation.flag")
+    params:
+        p1="|".join(["dbcan", "eggnog-mapper"]),
+        p2="|".join(["aragorn", "barrnap", "infernal"]),
+        p3="|".join(["prodigal", "bedtools", "biopython", "blast", "hmmer", "parallel", "diamond", "mmseqs2"])
+    resources:
+        mem=1
+    threads:
+        1
+    localrule: True
+    conda:
+        config["minto_dir"]+"/envs/gene_annotation.yml"
+    shell:
+        """
+        VOUT={working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > $VOUT
+        prokka --version >> $VOUT 2>&1
+        echo "kofamscan v$(exec_annotation --version | cut -d" " -f 2)" >> $VOUT
+        conda list | sed -E 's|[[:space:]]+| |g' | cut -d" " -f 1-2 | grep -P "{params.p1}" >> $VOUT
+        conda list | sed -E 's|[[:space:]]+| |g' | cut -d" " -f 1-2 | grep -P "{params.p2}" >> $VOUT
+        conda list | sed -E 's|[[:space:]]+| |g' | cut -d" " -f 1-2 | grep -P "{params.p3}" | grep -v "perl" >> $VOUT
+
+        echo "#----" >> $VOUT
+        echo "dbCAN database files" >> $VOUT
+        find $(dirname $(which dbcan_build))/.. -iname "dbcan_build.py" -type f -exec grep "dbCAN2/download/Databases" {{}} \; | grep -o -P "fam-substrate-mapping-.*.tsv|dbCAN-PUL_.*.xlsx|V12/CAZyDB.*.fa" >> $VOUT || echo "Error: dbcan_build.py not found"
+
+        echo "#----" >> $VOUT
+        echo "eggNOG database file $(sqlite3 {minto_dir}/data/eggnog_data/data/eggnog.db 'select * from version;')" >> $VOUT
+
+        echo "#----" >> $VOUT
+        echo "KEGG/kofamscan files" >> $VOUT
+        echo "KO profiles modification date $(stat -c '%y' {minto_dir}/data/kofam_db/profiles.tar.gz | cut -d" " -f 1)" >> $VOUT
+        echo "Module to KO file creation date $(stat -c '%y' {minto_dir}/data/kofam_db/KEGG_Module2KO.tsv | cut -d" " -f 1)" >> $VOUT
+        echo "Pathway to KO file creation date $(stat -c '%y' {minto_dir}/data/kofam_db/KEGG_Pathway2KO.tsv | cut -d" " -f 1)" >> $VOUT
+
+        touch {output}
+        """
+
+##################################
+#  Rules for gene_abundance
+##################################
+
+rule abundance_base:
+    output:
+        temp("{wd}/output/versions/abund_base.flag")
+    resources:
+        mem=1
+    threads:
+        1
+    localrule: True
+    conda:
+        config["minto_dir"]+"/envs/MIntO_base.yml"
+    shell:
+        """
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "bwa-mem2 v$(bwa-mem2 version 2> /dev/null)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "msamtools $(msamtools 2>&1 | grep "Version" | cut -d" " -f 2)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "samtools $(samtools 2>&1 | grep "Version" | cut -d" " -f 2)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        bedtools --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        touch {output}
+        """
+
+rule abundance_rpkg:
+    input:
+        "{wd}/output/versions/abund_base.flag".format(wd=working_dir)
+    output:
+        temp("{wd}/output/versions/gene_abundance.flag")
+    resources:
+        mem=1
+    threads: 1
+    localrule: True
+    conda:
+        config["minto_dir"]+"/envs/r_pkgs.yml"
+    shell:
+        """
+        Rscript --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        touch {output}
+        """
+
+##################################
+#  Rules for data_integration
+##################################
+
+rule integration_rpkg:
+    output:
+        temp("{wd}/output/versions/data_integration.flag")
+    resources:
+        mem=1
+    threads:
+        1
+    localrule: True
+    conda:
+        config["minto_dir"]+"/envs/r_pkgs.yml"
+    shell:
+        """
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        Rscript --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        conda list | sed -E 's|[[:space:]]+| |g' | cut -d" " -f 1-2 | grep -P "^r-.*" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        conda list | sed -E 's|[[:space:]]+| |g' | cut -d" " -f 1-2 | grep -P "^bioconductor-.*" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        touch {output}
+        """

--- a/smk/include/versions.smk
+++ b/smk/include/versions.smk
@@ -64,7 +64,7 @@ rule test_base:
         config["minto_dir"]+"/envs/MIntO_base.yml"
     shell:
         """
-        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference -q && cd - > /dev/null)" > {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
         touch {output}
         """
 
@@ -85,7 +85,7 @@ rule QC_0_base:
     shell:
         """
         VOUT={working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > $VOUT
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference -q && cd - > /dev/null)" > $VOUT
         fastqc --version >> $VOUT
         echo $(fastp --version 2>&1) >> $VOUT
         touch {output}
@@ -125,7 +125,7 @@ rule QC_1_base:
     shell:
         """
         VOUT={working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > $VOUT
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference -q && cd - > /dev/null)" > $VOUT
         echo "trimmomatic v$(trimmomatic -version)" >> $VOUT
         touch {output}
         """
@@ -164,7 +164,7 @@ rule QC_2_base:
     shell:
         """
         VOUT={working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > $VOUT
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference -q && cd - > /dev/null)" > $VOUT
         seqkit version >> $VOUT
         echo "bwa-mem2 v$(bwa-mem2 version 2> /dev/null)" >> $VOUT
         echo "msamtools $(msamtools 2>&1 | grep "Version" | cut -d" " -f 2)" >> $VOUT
@@ -246,7 +246,7 @@ rule assembly_base:
     shell:
         """
         VOUT={working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > $VOUT
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference -q && cd - > /dev/null)" > $VOUT
         $(which {spades_script}) --version >> $VOUT
         megahit --version >> $VOUT
         echo "flye v$(flye --version)" >> $VOUT
@@ -270,7 +270,7 @@ rule binning_preparation_base:
     shell:
         """
         VOUT={working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > $VOUT
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference -q && cd - > /dev/null)" > $VOUT
         echo "bwa-mem2 v$(bwa-mem2 version 2> /dev/null)" >> $VOUT
         echo "msamtools $(msamtools 2>&1 | grep "Version" | cut -d" " -f 2)" >> $VOUT
         echo "samtools $(samtools 2>&1 | grep "Version" | cut -d" " -f 2)" >> $VOUT
@@ -312,7 +312,7 @@ rule mags_base:
     shell:
         """
         VOUT={working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > $VOUT
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference -q && cd - > /dev/null)" > $VOUT
         coverm --version >> $VOUT
         touch {output}
         """
@@ -414,7 +414,7 @@ rule annotation_base:
     shell:
         """
         VOUT={working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > $VOUT
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference -q && cd - > /dev/null)" > $VOUT
         prokka --version >> $VOUT 2>&1
         echo "kofamscan v$(exec_annotation --version | cut -d" " -f 2)" >> $VOUT
         conda list | sed -E 's|[[:space:]]+| |g' | cut -d" " -f 1-2 | grep -P "{params.p1}" >> $VOUT
@@ -454,7 +454,7 @@ rule abundance_base:
     shell:
         """
         VOUT={working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > $VOUT
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference -q && cd - > /dev/null)" > $VOUT
         echo "bwa-mem2 v$(bwa-mem2 version 2> /dev/null)" >> $VOUT
         echo "msamtools $(msamtools 2>&1 | grep "Version" | cut -d" " -f 2)" >> $VOUT
         echo "samtools $(samtools 2>&1 | grep "Version" | cut -d" " -f 2)" >> $VOUT
@@ -496,7 +496,7 @@ rule integration_rpkg:
     shell:
         """
         VOUT={working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > $VOUT
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference -q && cd - > /dev/null)" > $VOUT
         Rscript --version >> $VOUT
         conda list | sed -E 's|[[:space:]]+| |g' | cut -d" " -f 1-2 | grep -P "^r-.*" >> $VOUT
         conda list | sed -E 's|[[:space:]]+| |g' | cut -d" " -f 1-2 | grep -P "^bioconductor-.*" >> $VOUT

--- a/smk/include/versions.smk
+++ b/smk/include/versions.smk
@@ -84,9 +84,10 @@ rule QC_0_base:
         config["minto_dir"]+"/envs/MIntO_base.yml"
     shell:
         """
-        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        fastqc --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo $(fastp --version 2>&1) >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        VOUT={working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > $VOUT
+        fastqc --version >> $VOUT
+        echo $(fastp --version 2>&1) >> $VOUT
         touch {output}
         """
 
@@ -123,8 +124,9 @@ rule QC_1_base:
         config["minto_dir"]+"/envs/MIntO_base.yml"
     shell:
         """
-        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo "trimmomatic v$(trimmomatic -version)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        VOUT={working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > $VOUT
+        echo "trimmomatic v$(trimmomatic -version)" >> $VOUT
         touch {output}
         """
 
@@ -161,13 +163,14 @@ rule QC_2_base:
         config["minto_dir"]+"/envs/MIntO_base.yml"
     shell:
         """
-        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        seqkit version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo "bwa-mem2 v$(bwa-mem2 version 2> /dev/null)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo "msamtools $(msamtools 2>&1 | grep "Version" | cut -d" " -f 2)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo "samtools $(samtools 2>&1 | grep "Version" | cut -d" " -f 2)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo "$(sortmerna 2>&1 | grep "Program" | cut -d" " -f 9-11)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        sourmash --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        VOUT={working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > $VOUT
+        seqkit version >> $VOUT
+        echo "bwa-mem2 v$(bwa-mem2 version 2> /dev/null)" >> $VOUT
+        echo "msamtools $(msamtools 2>&1 | grep "Version" | cut -d" " -f 2)" >> $VOUT
+        echo "samtools $(samtools 2>&1 | grep "Version" | cut -d" " -f 2)" >> $VOUT
+        echo "$(sortmerna 2>&1 | grep "Program" | cut -d" " -f 9-11)" >> $VOUT
+        sourmash --version >> $VOUT
         touch {output}
         """
 
@@ -184,8 +187,9 @@ rule QC_2_mpl:
         config["minto_dir"]+"/envs/metaphlan.yml"
     shell:
         """
-        metaphlan --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo "metaphlan database $(basename $(ls {minto_dir}/data/metaphlan/{metaphlan_version}/*.csv) | sed 's|_VINFO.csv||')" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        VOUT={working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        metaphlan --version >> $VOUT
+        echo "metaphlan database $(basename $(ls {minto_dir}/data/metaphlan/{metaphlan_version}/*.csv) | sed 's|_VINFO.csv||')" >> $VOUT
         touch {output}
         """
 
@@ -241,10 +245,11 @@ rule assembly_base:
         config["minto_dir"]+"/envs/MIntO_base.yml"
     shell:
         """
-        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        $(which {spades_script}) --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        megahit --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo "flye v$(flye --version)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        VOUT={working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > $VOUT
+        $(which {spades_script}) --version >> $VOUT
+        megahit --version >> $VOUT
+        echo "flye v$(flye --version)" >> $VOUT
         touch {output}
         """
 
@@ -264,11 +269,12 @@ rule binning_preparation_base:
         config["minto_dir"]+"/envs/MIntO_base.yml"
     shell:
         """
-        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo "bwa-mem2 v$(bwa-mem2 version 2> /dev/null)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo "msamtools $(msamtools 2>&1 | grep "Version" | cut -d" " -f 2)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo "samtools $(samtools 2>&1 | grep "Version" | cut -d" " -f 2)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        coverm --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        VOUT={working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > $VOUT
+        echo "bwa-mem2 v$(bwa-mem2 version 2> /dev/null)" >> $VOUT
+        echo "msamtools $(msamtools 2>&1 | grep "Version" | cut -d" " -f 2)" >> $VOUT
+        echo "samtools $(samtools 2>&1 | grep "Version" | cut -d" " -f 2)" >> $VOUT
+        coverm --version >> $VOUT
         touch {output}
         """
 
@@ -305,8 +311,9 @@ rule mags_base:
         config["minto_dir"]+"/envs/MIntO_base.yml"
     shell:
         """
-        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        coverm --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        VOUT={working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > $VOUT
+        coverm --version >> $VOUT
         touch {output}
         """
 
@@ -359,8 +366,9 @@ rule mags_ppl:
         config["minto_dir"]+"/envs/mags.yml"
     shell:
         """
-        phylophlan --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo "phylophlan database {params.db}" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        VOUT={working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        phylophlan --version >> $VOUT
+        echo "phylophlan database {params.db}" >> $VOUT
         touch {output}
         """
 
@@ -379,8 +387,9 @@ rule mags_gtdb:
         config["minto_dir"]+"/envs/gtdb.yml"
     shell:
         """
-        echo "gtdbtk v$(gtdbtk --version | cut -d" " -f 3 | head -n 1)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo "gtdbtk database {params.db}" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        VOUT={working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "gtdbtk v$(gtdbtk --version | cut -d" " -f 3 | head -n 1)" >> $VOUT
+        echo "gtdbtk database {params.db}" >> $VOUT
         touch {output}
         """
 
@@ -444,11 +453,12 @@ rule abundance_base:
         config["minto_dir"]+"/envs/MIntO_base.yml"
     shell:
         """
-        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo "bwa-mem2 v$(bwa-mem2 version 2> /dev/null)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo "msamtools $(msamtools 2>&1 | grep "Version" | cut -d" " -f 2)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        echo "samtools $(samtools 2>&1 | grep "Version" | cut -d" " -f 2)" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        bedtools --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        VOUT={working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > $VOUT
+        echo "bwa-mem2 v$(bwa-mem2 version 2> /dev/null)" >> $VOUT
+        echo "msamtools $(msamtools 2>&1 | grep "Version" | cut -d" " -f 2)" >> $VOUT
+        echo "samtools $(samtools 2>&1 | grep "Version" | cut -d" " -f 2)" >> $VOUT
+        bedtools --version >> $VOUT
         touch {output}
         """
 
@@ -485,9 +495,10 @@ rule integration_rpkg:
         config["minto_dir"]+"/envs/r_pkgs.yml"
     shell:
         """
-        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        Rscript --version >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        conda list | sed -E 's|[[:space:]]+| |g' | cut -d" " -f 1-2 | grep -P "^r-.*" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
-        conda list | sed -E 's|[[:space:]]+| |g' | cut -d" " -f 1-2 | grep -P "^bioconductor-.*" >> {working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        VOUT={working_dir}/output/versions/{snakefile_name}.$(date "+%Y-%m-%d").txt
+        echo "MIntO git commit $(cd {minto_dir} && git show --pretty=reference && cd - > /dev/null)" > $VOUT
+        Rscript --version >> $VOUT
+        conda list | sed -E 's|[[:space:]]+| |g' | cut -d" " -f 1-2 | grep -P "^r-.*" >> $VOUT
+        conda list | sed -E 's|[[:space:]]+| |g' | cut -d" " -f 1-2 | grep -P "^bioconductor-.*" >> $VOUT
         touch {output}
         """

--- a/smk/mags_generation.smk
+++ b/smk/mags_generation.smk
@@ -28,6 +28,15 @@ localrules: aae_tsv, vae_tsv, collect_genomes_from_all_binners, copy_best_genome
 include: 'include/cmdline_validator.smk'
 include: 'include/config_parser.smk'
 
+module print_versions:
+    snakefile:
+        'include/versions.smk'
+    config: config
+
+use rule mags_base, mags_rpkg, mags_checkm2, mags_ppl, mags_gtdb from print_versions as version_*
+
+snakefile_name = print_versions.get_smk_filename()
+
 # Variables from configuration yaml file
 
 # some variables
@@ -181,7 +190,9 @@ def mags_recovery():
 
 rule all:
     input:
-        mags_recovery()
+        mags_recovery(),
+        print_versions.get_version_output(snakefile_name)
+    default_target: True
 
 ##############################
 


### PR DESCRIPTION
Print version information into txt files in ouput/versions/ for each smk run, and database information for the annotation tsv-s.
Moved taxonomy profiler versions into yaml.
Plus some bug-fixes.