### PR TITLE
Feature: bulk input in one folder

### DIFF
--- a/smk/QC_1.smk
+++ b/smk/QC_1.smk
@@ -120,17 +120,6 @@ if 'ILLUMINA' in config:
 
 # Define all the outputs needed by target 'all'
 
-def qc1_check_read_length_output():
-    result = expand("{wd}/{omics}/1-trimmed/{sample}/{sample}.{group}.read_length.txt",
-                    wd = working_dir,
-                    omics = omics,
-                    sample = ilmn_samples,
-                    group = ['1', '2']),\
-    expand("{wd}/{omics}/1-trimmed/samples_read_length.txt",
-                    wd = working_dir,
-                    omics = omics)
-    return(result)
-
 def qc1_read_length_cutoff_output():
     result = expand("{wd}/output/1-trimmed/{omics}_cumulative_read_length_cutoff.pdf",
                     wd = working_dir,

--- a/testing/QC_1.bulk.yaml.in
+++ b/testing/QC_1.bulk.yaml.in
@@ -1,0 +1,34 @@
+######################
+# General settings
+######################
+
+PROJECT: IBD_tutorial
+working_dir: <__TEST_DIR__>/IBD_tutorial
+omics: <__OMICS__>
+minto_dir: <__MINTO_DIR__>
+METADATA: <__TEST_DIR__>/IBD_tutorial/tutorial_metadata.txt
+raw_reads_dir: <__TEST_DIR__>/IBD_tutorial_bulk/<__OMICS__>
+
+######################
+# Program settings
+######################
+# Read quality filtering
+MULTIPLEX_TECH: TruSeq
+TRIMMOMATIC_adaptors: Quality
+TRIMMOMATIC_palindrome:
+TRIMMOMATIC_index_barcodes:
+TRIMMOMATIC_simple_clip_threshold:
+TRIMMOMATIC_threads: 8
+TRIMMOMATIC_memory: 5
+perc_remaining_reads: 95
+
+# Input data
+# ILLUMINA section:
+# -----------------
+# List of illumina samples that will be filtered by quality.
+#
+# E.g.:
+# - I1
+# - I2
+#
+ILLUMINA: <__MINTO_DIR__>/testing/test_runs_sheet.tsv

--- a/testing/run_IBD_test.sh
+++ b/testing/run_IBD_test.sh
@@ -95,6 +95,16 @@ if [ ! -d "IBD_tutorial_raw" ]; then
 fi
 echo ""
 
+# Symlink samples for testing bulk mode
+
+if [[ "$1" = "--bulk" ]]; then
+  mkdir -p IBD_tutorial_bulk/metaG
+  for SAMPLE in CD136 CD140 CD237 CD240;
+  do
+    find $PWD/IBD_tutorial_raw/metaG/${SAMPLE} -type f -exec ln -s {} IBD_tutorial_bulk/metaG/ \;
+  done
+fi
+
 # Extract ref-genome
 
 tar xfz $MINTO_DIR/tutorial/genomes.tar.gz
@@ -125,6 +135,13 @@ for OMICS in metaG metaT; do
   cd $OMICS
 
   COMMAND_LOG="commands_${OMICS}.txt"
+
+  if [[ "$1" == "--bulk" && "$OMICS" == "metaG" ]]; then
+      echo -n "QC_1 bulk: "
+      cat $MINTO_DIR/testing/QC_1.bulk.yaml.in | sed "s@<__MINTO_DIR__>@$MINTO_DIR@;s@<__TEST_DIR__>@$TEST_DIR@;s@<__OMICS__>@$OMICS@;" > QC_1.bulk.yaml
+      cmd="snakemake --snakefile $CODE_DIR/smk/QC_1.smk --configfile QC_1.bulk.yaml $SNAKE_PARAMS >& QC_1_bulk.log"
+      profile_command "$cmd"
+  fi
 
   echo -n "QC_1: "
   cat $MINTO_DIR/testing/QC_1.yaml.in | sed "s@<__MINTO_DIR__>@$MINTO_DIR@;s@<__TEST_DIR__>@$TEST_DIR@;s@<__OMICS__>@$OMICS@;" > QC_1.yaml

--- a/testing/test_runs_sheet.tsv
+++ b/testing/test_runs_sheet.tsv
@@ -1,0 +1,7 @@
+sample	run
+CD136	run_ab
+CD136	run_aa
+CD136	run_ac
+CD140	CD140
+CD237	CD237
+CD240	CD240


### PR DESCRIPTION
Added option to QC_1 and QC_0 to process raw fastq files in one common folder, with run names specified for each sample in an tsv (columns: sample, run) 