### PR TITLE
Make NFS file staging more robust against transient flock failures

### DIFF
--- a/include/file_staging_functions.sh
+++ b/include/file_staging_functions.sh
@@ -184,7 +184,7 @@ stage_multiple_files_in() {
     }
 
     # Jitter: wait for a random amount of seconds (1–60) to avoid stampedes
-    #sleep $((RANDOM % 60 + 1))
+    sleep $((RANDOM % 60 + 1))
 
     # Get one of five host-specific locks randomly
     # Determine stable lock id based on host name

--- a/include/file_staging_functions.sh
+++ b/include/file_staging_functions.sh
@@ -33,6 +33,16 @@
 #   - LOCAL_DIR is node-local storage (e.g. /scratch, /tmp, /local).
 #   - REMOTE_FILE is accessible via shared FS (NFS / Lustre / GPFS).
 #   - rsync is available on execution nodes.
+#   - The filesystem holding REMOTE_FILE supports POSIX advisory locking
+#     (flock). On problematic NFS mounts, you may see:
+#         "flock: <fd>: No locks available"
+#     In that case, consult your cluster admins or switch to a mkdir-based
+#     locking scheme.
+#
+#   - To test locking support on REMOTE_FILE's filesystem, run on a node:
+#         touch /path/on/nfs/test.lock
+#         flock -x /path/on/nfs/test.lock -c 'echo "lock ok"; sleep 5'
+#     This should print "lock ok" and exit without errors.
 #
 # ---------------------------------------------------------------------------
 
@@ -75,19 +85,45 @@ stage_file_in() {
     remote_lock="${remote_file}.lock.${lock_id}"
     local_lock="${local_copy}.lock"
 
+    ####
     # Acquire an exclusive lock on the remote lockfile
+    #  - Sometimes NFS fails to provide the lock on the file.
+    #    This is why we try it 10 times with 60s waits
+    #    in between, to catch the random inability of the kernel
+    #    to provide the lock.
+    ####
+
+    # Prepare the lock file
     exec 9> "$remote_lock" || {
         echo "Cannot open lock file $remote_lock" >&2
         return 1
     }
-    # Wait up to 3600s to acquire the lock
-    if ! flock -w 3600 9; then
-        echo "Could not acquire lock on $remote_lock within 3600 seconds" >&2
+
+    # Attempt to lock the file
+    local acquired=0
+    local attempt
+    for attempt in $(seq 1 10); do
+        if flock -w 60 9; then
+            acquired=1
+            break
+        else
+            echo "WARN: flock failed on $remote_lock (attempt $attempt), retrying in 60 seconds..." >&2
+            sleep 60
+        fi
+    done
+
+    # handle failure
+    if [ "$acquired" -ne 1 ]; then
+        echo "ERROR: Could not acquire lock on $remote_lock after $attempt retries" >&2
         exec 9>&-
         return 1
     fi
 
+    # If we are here, NFS lock succeeded!
+
+    ####
     # Acquire an exclusive lock on the local copy lockfile
+    ####
     exec 8> "$local_lock" || {
         echo "Cannot open lock file $local_lock" >&2
         exec 9>&-
@@ -103,33 +139,23 @@ stage_file_in() {
     # At this point we hold both locks (FDs 9 and 8).
     # But ONLY for the duration of the rsync loop.
 
-    local attempts=0
     local rsync_rc=0
 
-    # We set max_attempts to 1, as it is designed for use from within Snakemake
+    # Here, we only try once, as it is designed for use from within Snakemake
     # where "fail early" is the best approach. There might already be a
     # "--restart-times=N" option given to Snakemake, which might make this
-    # even slower to catch an error when max_attempts > 1.
-    while (( attempts < 1 )); do
-        if rsync --itemize-changes -a -- "$remote_file" "$local_copy"; then
-            rsync_rc=0
-            break
-        fi
+    # even slower to catch an error when we try multiple times.
+
+    if ! rsync --itemize-changes -a -- "$remote_file" "$local_copy"; then
         rsync_rc=$?
-        attempts=$(( attempts + 1 ))
-        echo "rsync failed for $remote_file -> $local_copy (attempt $attempts, rc=$rsync_rc), retrying..." >&2
-        sleep 1
-    done
-
-    # release the locks before returning
-    exec 8>&-
-    exec 9>&-
-
-    if (( attempts == 10 )); then
-        echo "Staging $remote_file to $local_copy failed after $attempts attempts (last rc=$rsync_rc)." >&2
-        echo "Please copy it manually or investigate network/storage issues." >&2
+        echo "rsync failed for $remote_file -> $local_copy (rc=$rsync_rc)." >&2
+        exec 8>&-
+        exec 9>&-
         return 1
     fi
+
+    exec 8>&-
+    exec 9>&-
 
     # No need to rm lock files. The locks are released automatically when
     # the shell closes FDs 8 and 9 (i.e. when this function/parent shell exits).
@@ -144,7 +170,7 @@ stage_multiple_files_in() {
 
     # Require at least 2 arguments: local dir, and at least one remote file
     if [[ -z "$local_location" || $# -lt 2 ]]; then
-        echo "Usage: stage_multiple_files_in LOCAL_DIR LOCK_ID REMOTE_FILE1 [REMOTE_FILE2 ...]" >&2
+        echo "Usage: stage_multiple_files_in LOCAL_DIR REMOTE_FILE1 [REMOTE_FILE2 ...]" >&2
         return 2
     fi
 
@@ -181,31 +207,31 @@ stage_multiple_files_in() {
 }
 
 stage_file_out() {
-	local local_file=$1;
-	local remote_dir=$2;
+	local local_file=$1
+	local remote_dir=$2
 	if [ -z "$remote_dir" ]; then
-		echo "Usage: stage_file_out local-file remote-dir" 1>&2;
-		exit 2;
+		echo "Usage: stage_file_out local-file remote-dir" 1>&2
+		exit 2
 	fi;
 
-	local file=$(basename $local_file);
-	local remote_copy="$remote_dir/$file";
+	local file=$(basename $local_file)
+	local remote_copy="$remote_dir/$file"
 
-	local attempts=0;
-	local copy=1;
+	local attempts=0
+	local copy=1
 	while [ $attempts -lt 10 -a $copy -eq 1 ]; do
-		rsync -q -ptg $local_file $remote_copy;
+		rsync -q -ptg -- "$local_file" "$remote_copy"
 		if [ $? -ne 0 ] ; then  # rsync failed!
-			copy=1;
-			attempts=$(expr $attempts + 1);
+			copy=1
+			attempts=$(expr $attempts + 1)
 		else
-			copy=0;
-		fi;
+			copy=0
+		fi
 	done
 	if [ $attempts -eq 10 ]; then
-		echo "Staging out $local_file to $remote_dir/ failed after $attempts attempts! Please copy it yourself by running:" 1>&2;
-		echo "rsync -a $(hostname):$local_file $remote_dir/" 1>&2;
+		echo "Staging out $local_file to $remote_dir/ failed after $attempts attempts! Please copy it yourself by running:" 1>&2
+		echo "rsync -a $(hostname):$local_file $remote_dir/" 1>&2
 	else
-		rm -f $local_file;
+		rm -f $local_file
 	fi
 }

--- a/smk/QC_0.smk
+++ b/smk/QC_0.smk
@@ -497,17 +497,25 @@ READ_minlen: $(cat {input.cutoff_file})
 # Host genome filtering
 #########################
 
-# bwa-mem2 index files will be stored at: <PATH_host_genome>/BWA_index/<NAME_host_genome>.*
-# If it already exists, then it will be used directly.
-# If not, a fasta file should exist as: <PATH_host_genome>/<NAME_host_genome>
-# This will be build into index files using:
-#    bwa-mem2 index -p <PATH_host_genome>/BWA_index/<NAME_host_genome> <PATH_host_genome>/<NAME_host_genome>
+# Path of the host genome file: <PATH_host_genome>/<NAME_host_genome>
+# Inferred location for bwa-mem2/strobealign index files: <PATH_host_genome>/{{BWA|STROBEALIGN}}_index/<NAME_host_genome>.*
+# If index files already exist, then they will be used directly.
+# If not, a fasta file should exist exactly as: <PATH_host_genome>/<NAME_host_genome>
+#   which will be used to build the index files in the inferred location above.
 
-PATH_host_genome:
-NAME_host_genome:
-BWA_index_host_memory: 100
-BWA_host_threads: 8
-BWA_host_memory: 40
+PATH_host_genome: None
+NAME_host_genome: None
+
+# Should host genome index files be cached in a local mirror?
+# If yes, set the path here.
+# If no,  set it to None
+
+LOCAL_DATABASE_CACHE_DIR: None
+
+# Which aligner or mapper to use: currently only 'bwa' is supported
+
+ALIGNER_type: bwa
+ALIGNER_threads: 8
 ___EOF___
 
         if [ "{omics}" == "metaT" ]; then
@@ -569,18 +577,36 @@ MAIN_factor:
 PLOT_factor2:
 PLOT_time:
 
+#####################
+# Co-assembly grouping
+#####################
+
+# COAS_factor - The factor/attribute to use to group samples for co-assembly
+
+COAS_factor:
+
 ######################
 # Optionally, do you want to merge replicates or make pseudo samples
 # E.g:
 # MERGE_ILLUMINA_SAMPLES:
-#  - merged=rep1+rep2+rep3
+#  sample1: rep1a+rep1b+rep1c
+#  sample2: rep2a+rep2b+rep2c
 #
-# The above directive will combine 3 samples (rep1, rep2 and rep3)
-# after the last step into a new sample called 'merged'. Now you can remove
-# rep1, rep2 and rep3 from assembly, MAG generation and profiling steps.
-# Please note that METADATA file must have an entry for 'merged' as well,
+# The above directive will make 2 new composite or pseudo samples at the end of QC_2.
+# Imagine you had triplicates for sample1 named as rep1a, rep1b and rep1c.
+# And likewise for sample2. The directive above will:
+#     - combine 3 samples (rep1a, rep1b and rep1c)into a new sample called 'sample1'.
+#     - combine 3 samples (rep2a, rep2b and rep2c)into a new sample called 'sample2'.
+# For all subsequent steps, namely:
+#     - profiling (done within this snakemake script),
+#     - assembly (done by assembly.smk),
+#     - binning (done by binning_preparation.smk and mags_generation.smk),
+# you can just use 'sample2' instead of the replicates rep2a, rep2b and rep2c in the yaml files.
+# Please note that METADATA file must have an entry for 'sample2' as well,
 # otherwise QC_2 step will fail.
 # Having extra entries in METADATA file does not affect you in any way.
+# Therefore, it is safe to have metadata recorded for
+# rep2a, rep2b, rep2c, sample2 from the beginning.
 ######################
 
 #MERGE_ILLUMINA_SAMPLES:


### PR DESCRIPTION
This PR improves the robustness of node-local file staging on shared NFS filesystems by adding retry logic around `flock` operations on remote lockfiles. This mitigates rare but disruptive `ENOLCK` (“No locks available”) errors observed under high cluster load on Isilon NFSv3 mounts.